### PR TITLE
Allow I2C to be used by DV Display and MicroPython user

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -101,7 +101,7 @@ jobs:
     # Check out Pimoroni Pico
     - uses: actions/checkout@v3
       with:
-        repository: pimoroni/pimoroni-pico
+        repository: MichaelBell/pimoroni-pico
         ref: ${{env.PIMORONI_PICO_VERSION}}
         submodules: true
         path: pimoroni-pico

--- a/modules/picographics/picographics.c
+++ b/modules/picographics/picographics.c
@@ -45,6 +45,7 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ModPicoGraphics_sprite_obj, 5, 7, ModPicoGra
 MP_DEFINE_CONST_FUN_OBJ_1(ModPicoGraphics_get_bounds_obj, ModPicoGraphics_get_bounds);
 MP_DEFINE_CONST_FUN_OBJ_2(ModPicoGraphics_set_font_obj, ModPicoGraphics_set_font);
 
+MP_DEFINE_CONST_FUN_OBJ_1(ModPicoGraphics_get_i2c_obj, ModPicoGraphics_get_i2c);
 
 MP_DEFINE_CONST_FUN_OBJ_1(ModPicoGraphics__del__obj, ModPicoGraphics__del__);
 
@@ -81,6 +82,8 @@ STATIC const mp_rom_map_elem_t ModPicoGraphics_locals_dict_table[] = {
     //{ MP_ROM_QSTR(MP_QSTR_set_scanline_callback), MP_ROM_PTR(&ModPicoGraphics_set_scanline_callback_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_bounds), MP_ROM_PTR(&ModPicoGraphics_get_bounds_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_font), MP_ROM_PTR(&ModPicoGraphics_set_font_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_get_i2c), MP_ROM_PTR(&ModPicoGraphics_get_i2c_obj) },
 
     { MP_ROM_QSTR(MP_QSTR___del__), MP_ROM_PTR(&ModPicoGraphics__del__obj) },
 };

--- a/modules/picographics/picographics.cpp
+++ b/modules/picographics/picographics.cpp
@@ -8,6 +8,7 @@ using namespace pimoroni;
 
 extern "C" {
 #include "picographics.h"
+#include "pimoroni_i2c.h"
 #include "py/stream.h"
 #include "py/reader.h"
 #include "extmod/vfs.h"
@@ -20,7 +21,8 @@ const std::string_view mp_obj_to_string_r(const mp_obj_t &obj) {
     mp_raise_TypeError("can't convert object to str implicitly");
 }
 
-static DVDisplay dv_display;
+static I2C dv_i2c(DVDisplay::I2C_SDA, DVDisplay::I2C_SCL);
+static DVDisplay dv_display(&dv_i2c);
 
 typedef struct _ModPicoGraphics_obj_t {
     mp_obj_base_t base;
@@ -599,5 +601,14 @@ mp_obj_t ModPicoGraphics_line(size_t n_args, const mp_obj_t *args) {
     }
 
     return mp_const_none;
+}
+
+mp_obj_t ModPicoGraphics_get_i2c(mp_obj_t self_in) {
+    _PimoroniI2C_obj_t* i2c_obj = m_new_obj(_PimoroniI2C_obj_t);
+    i2c_obj->base.type = &PimoroniI2C_type;
+
+    i2c_obj->i2c = &dv_i2c;
+
+    return i2c_obj;
 }
 }

--- a/modules/picographics/picographics.cpp
+++ b/modules/picographics/picographics.cpp
@@ -96,12 +96,7 @@ mp_obj_t ModPicoGraphics_make_new(const mp_obj_type_t *type, size_t n_args, size
 }
 
 mp_obj_t ModPicoGraphics__del__(mp_obj_t self_in) {
-    ModPicoGraphics_obj_t *self = MP_OBJ_TO_PTR2(self_in, ModPicoGraphics_obj_t);
-    for(auto x = 0u; x < 2u; x++){
-        self->graphics->set_pen(0);
-        self->graphics->clear();
-        dv_display.flip();
-    }
+    dv_display.reset();
     return mp_const_none;
 }
 

--- a/modules/picographics/picographics.h
+++ b/modules/picographics/picographics.h
@@ -111,4 +111,6 @@ extern mp_obj_t ModPicoGraphics_set_framebuffer(mp_obj_t self_in, mp_obj_t frame
 
 extern mp_int_t ModPicoGraphics_get_framebuffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags);
 
+extern mp_obj_t ModPicoGraphics_get_i2c(mp_obj_t self_in);
+
 extern mp_obj_t ModPicoGraphics__del__(mp_obj_t self_in);


### PR DESCRIPTION
This, in combination with the changes on my fork of the dv_stick branch, allows the I2C interface to be provided from MicroPython, so you can hook up all your favourite I2C goodies to PicoVision