### PR TITLE
Sprites from PNGs

### DIFF
--- a/modules/picographics/picographics.c
+++ b/modules/picographics/picographics.c
@@ -40,9 +40,10 @@ MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ModPicoGraphics_triangle_obj, 7, 7, ModPicoG
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ModPicoGraphics_line_obj, 5, 6, ModPicoGraphics_line);
 
 // Sprites
-MP_DEFINE_CONST_FUN_OBJ_2(ModPicoGraphics_set_spritesheet_obj, ModPicoGraphics_set_spritesheet);
-MP_DEFINE_CONST_FUN_OBJ_2(ModPicoGraphics_load_spritesheet_obj, ModPicoGraphics_load_spritesheet);
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ModPicoGraphics_sprite_obj, 5, 7, ModPicoGraphics_sprite);
+//MP_DEFINE_CONST_FUN_OBJ_2(ModPicoGraphics_set_spritesheet_obj, ModPicoGraphics_set_spritesheet);
+//MP_DEFINE_CONST_FUN_OBJ_2(ModPicoGraphics_load_spritesheet_obj, ModPicoGraphics_load_spritesheet);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ModPicoGraphics_display_sprite_obj, 5, 5, ModPicoGraphics_display_sprite);
+MP_DEFINE_CONST_FUN_OBJ_2(ModPicoGraphics_clear_sprite_obj, ModPicoGraphics_clear_sprite);
 
 // Utility
 //MP_DEFINE_CONST_FUN_OBJ_2(ModPicoGraphics_set_scanline_callback_obj, ModPicoGraphics_set_scanline_callback);
@@ -76,9 +77,10 @@ STATIC const mp_rom_map_elem_t ModPicoGraphics_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_triangle), MP_ROM_PTR(&ModPicoGraphics_triangle_obj) },
     { MP_ROM_QSTR(MP_QSTR_line), MP_ROM_PTR(&ModPicoGraphics_line_obj) },
 
-    { MP_ROM_QSTR(MP_QSTR_set_spritesheet), MP_ROM_PTR(&ModPicoGraphics_set_spritesheet_obj) },
-    { MP_ROM_QSTR(MP_QSTR_load_spritesheet), MP_ROM_PTR(&ModPicoGraphics_load_spritesheet_obj) },
-    { MP_ROM_QSTR(MP_QSTR_sprite), MP_ROM_PTR(&ModPicoGraphics_sprite_obj) },
+    //{ MP_ROM_QSTR(MP_QSTR_set_spritesheet), MP_ROM_PTR(&ModPicoGraphics_set_spritesheet_obj) },
+    //{ MP_ROM_QSTR(MP_QSTR_load_spritesheet), MP_ROM_PTR(&ModPicoGraphics_load_spritesheet_obj) },
+    { MP_ROM_QSTR(MP_QSTR_display_sprite), MP_ROM_PTR(&ModPicoGraphics_display_sprite_obj) },
+    { MP_ROM_QSTR(MP_QSTR_clear_sprite), MP_ROM_PTR(&ModPicoGraphics_clear_sprite_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_create_pen), MP_ROM_PTR(&ModPicoGraphics_create_pen_obj) },
     { MP_ROM_QSTR(MP_QSTR_create_pen_hsv), MP_ROM_PTR(&ModPicoGraphics_create_pen_hsv_obj) },

--- a/modules/picographics/picographics.cpp
+++ b/modules/picographics/picographics.cpp
@@ -27,7 +27,7 @@ static DVDisplay dv_display(&dv_i2c);
 typedef struct _ModPicoGraphics_obj_t {
     mp_obj_base_t base;
     PicoGraphics *graphics;
-    void *spritedata;
+    DVDisplay *display;
 } ModPicoGraphics_obj_t;
 
 size_t get_required_buffer_size(PicoGraphicsPenType pen_type, uint width, uint height) {
@@ -90,7 +90,7 @@ mp_obj_t ModPicoGraphics_make_new(const mp_obj_type_t *type, size_t n_args, size
             break;
     }
 
-    self->spritedata = nullptr;
+    self->display = &dv_display;
 
     // Clear each buffer
     for(auto x = 0u; x < 2u; x++){
@@ -143,7 +143,7 @@ mp_obj_t ModPicoGraphics_set_scroll_index_for_lines(size_t n_args, const mp_obj_
     return mp_const_none;
 }
 
-
+#if 0
 mp_obj_t ModPicoGraphics_set_spritesheet(mp_obj_t self_in, mp_obj_t spritedata) {
     ModPicoGraphics_obj_t *self = MP_OBJ_TO_PTR2(self_in, ModPicoGraphics_obj_t);
     if(spritedata == mp_const_none) {
@@ -189,29 +189,21 @@ mp_obj_t ModPicoGraphics_load_spritesheet(mp_obj_t self_in, mp_obj_t filename) {
 
     return mp_const_none;
 }
+#endif
 
-mp_obj_t ModPicoGraphics_sprite(size_t n_args, const mp_obj_t *args) {
-    enum { ARG_self, ARG_sprite_x, ARG_sprite_y, ARG_x, ARG_y, ARG_scale, ARG_transparent };
+mp_obj_t ModPicoGraphics_display_sprite(size_t n_args, const mp_obj_t *args) {
+    enum { ARG_self, ARG_slot, ARG_sprite_index, ARG_x, ARG_y };
 
-    ModPicoGraphics_obj_t *self = MP_OBJ_TO_PTR2(args[ARG_self], ModPicoGraphics_obj_t);
-
-    if(self->spritedata == nullptr) return mp_const_false;
-
-    int scale = 1;
-    int transparent = 0;
-
-    if(n_args >= 6) scale = mp_obj_get_int(args[ARG_scale]);
-    if(n_args >= 7) transparent = mp_obj_get_int(args[ARG_transparent]);
-
-    self->graphics->sprite(
-        self->spritedata,
-        {mp_obj_get_int(args[ARG_sprite_x]), mp_obj_get_int(args[ARG_sprite_y])},
-        {mp_obj_get_int(args[ARG_x]), mp_obj_get_int(args[ARG_y])},
-        scale,
-        transparent
-    );
+    dv_display.set_sprite(mp_obj_get_int(args[ARG_slot]), 
+                          mp_obj_get_int(args[ARG_sprite_index]),
+                          {mp_obj_get_int(args[ARG_x]), mp_obj_get_int(args[ARG_y])});
 
     return mp_const_true;
+}
+
+mp_obj_t ModPicoGraphics_clear_sprite(mp_obj_t self_in, mp_obj_t slot) {
+    dv_display.clear_sprite(mp_obj_get_int(slot));
+    return mp_const_none;
 }
 
 mp_obj_t ModPicoGraphics_set_font(mp_obj_t self_in, mp_obj_t font) {

--- a/modules/picographics/picographics.h
+++ b/modules/picographics/picographics.h
@@ -103,9 +103,10 @@ extern mp_obj_t ModPicoGraphics_triangle(size_t n_args, const mp_obj_t *args);
 extern mp_obj_t ModPicoGraphics_line(size_t n_args, const mp_obj_t *args);
 
 // Sprites
-extern mp_obj_t ModPicoGraphics_set_spritesheet(mp_obj_t self_in, mp_obj_t spritedata);
-extern mp_obj_t ModPicoGraphics_load_spritesheet(mp_obj_t self_in, mp_obj_t filename);
-extern mp_obj_t ModPicoGraphics_sprite(size_t n_args, const mp_obj_t *args);
+//extern mp_obj_t ModPicoGraphics_set_spritesheet(mp_obj_t self_in, mp_obj_t spritedata);
+//extern mp_obj_t ModPicoGraphics_load_spritesheet(mp_obj_t self_in, mp_obj_t filename);
+extern mp_obj_t ModPicoGraphics_display_sprite(size_t n_args, const mp_obj_t *args);
+extern mp_obj_t ModPicoGraphics_clear_sprite(mp_obj_t self_in, mp_obj_t slot);
 
 // Utility
 //extern mp_obj_t ModPicoGraphics_set_scanline_callback(mp_obj_t self_in, mp_obj_t cb_in);

--- a/modules/pngdec/pngdec.c
+++ b/modules/pngdec/pngdec.c
@@ -4,6 +4,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(PNG_del_obj, _PNG_del);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(PNG_openRAM_obj, _PNG_openRAM);
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(PNG_openFILE_obj, _PNG_openFILE);
 STATIC MP_DEFINE_CONST_FUN_OBJ_KW(PNG_decode_obj, 1, _PNG_decode);
+STATIC MP_DEFINE_CONST_FUN_OBJ_KW(PNG_decode_as_sprite_obj, 2, _PNG_decode_as_sprite);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(PNG_getWidth_obj, _PNG_getWidth);
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(PNG_getHeight_obj, _PNG_getHeight);
 
@@ -13,6 +14,7 @@ STATIC const mp_rom_map_elem_t PNG_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_open_RAM), MP_ROM_PTR(&PNG_openRAM_obj) },
     { MP_ROM_QSTR(MP_QSTR_open_file), MP_ROM_PTR(&PNG_openFILE_obj) },
     { MP_ROM_QSTR(MP_QSTR_decode), MP_ROM_PTR(&PNG_decode_obj) },
+    { MP_ROM_QSTR(MP_QSTR_decode_as_sprite), MP_ROM_PTR(&PNG_decode_as_sprite_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_width), MP_ROM_PTR(&PNG_getWidth_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_height), MP_ROM_PTR(&PNG_getHeight_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_height), MP_ROM_PTR(&PNG_getHeight_obj) },

--- a/modules/pngdec/pngdec.h
+++ b/modules/pngdec/pngdec.h
@@ -8,5 +8,6 @@ extern mp_obj_t _PNG_del(mp_obj_t self_in);
 extern mp_obj_t _PNG_openRAM(mp_obj_t self_in, mp_obj_t buffer);
 extern mp_obj_t _PNG_openFILE(mp_obj_t self_in, mp_obj_t filename);
 extern mp_obj_t _PNG_decode(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
+extern mp_obj_t _PNG_decode_as_sprite(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args);
 extern mp_obj_t _PNG_getWidth(mp_obj_t self_in);
 extern mp_obj_t _PNG_getHeight(mp_obj_t self_in);


### PR DESCRIPTION
This change removes the old PicoDisplay style spritesheet and instead exposes the PicoVision sprite interface.

Sprites can be defined by loading them from a PNG file with PNG.decode_as_sprite.  Note that you have to define them on each RAM bank, we might want to think about allowing them to be set them up before init so that they could just be loaded to both banks.

Example MicroPython:
```
display = PicoGraphics(DISPLAY_PICOVISION, width=WIDTH, height=HEIGHT, pen_type=PEN_DV_RGB555)

png = pngdec.PNG(display)
png.open_file("smile.png")
png.decode_as_sprite(1)
display.update()
display.display_sprite(0, 1, int(self.x), int(self.y))
```

The sprite image should be no bigger than 1024 pixels, with maximum width and height of 64.  (32x32 is the standard size, but you can have rectangular sprites if you like)