### PR TITLE
Fast tile alpha blending for RGB555 mode

### DIFF
--- a/drivers/dv_display/dv_display.hpp
+++ b/drivers/dv_display/dv_display.hpp
@@ -217,6 +217,14 @@ namespace pimoroni {
       // The supplied buffer must be at least 128 bytes long
       void get_edid(uint8_t* edid);
 
+      // Raw access to frame buffer
+      uint32_t point_to_address(const Point& p) const;
+      int pixel_size() const;
+      int frame_row_stride() const { return (int)frame_width * 6; }
+      void raw_read_async(uint32_t address, uint32_t* data, uint32_t len_in_words) { ram.read(address, data, len_in_words); }
+      void raw_write_async(uint32_t address, uint32_t* data, uint32_t len_in_words) { ram.write(address, data, len_in_words << 2); }
+      void raw_wait_for_finish_blocking() { ram.wait_for_finish_blocking(); }
+
     protected:
       uint8_t palette[NUM_PALETTES * PALETTE_SIZE * 3] alignas(4);
       bool rewrite_header = false;
@@ -243,9 +251,6 @@ namespace pimoroni {
       void write(uint32_t address, size_t len, const RGB888 colour);
 
       void define_sprite_internal(uint16_t sprite_data_idx, uint16_t width, uint16_t height, uint32_t* data, uint32_t bytes_per_pixel);
-
-      uint32_t point_to_address(const Point& p) const;
-      int pixel_size() const;
 
       uint32_t point_to_address16(const Point &p) const {
         return base_address + ((p.y * (uint32_t)frame_width * 3) + p.x) * 2;

--- a/libraries/pico_graphics/pico_graphics_dv.hpp
+++ b/libraries/pico_graphics/pico_graphics_dv.hpp
@@ -18,6 +18,8 @@ namespace pimoroni {
 
       bool supports_alpha_blend() override {return true;}
 
+      bool render_pico_vector_tile(const Rect &bounds, uint8_t* alpha_data, uint32_t stride, uint8_t alpha_type) override;
+
       static size_t buffer_size(uint w, uint h) {
         return w * h * sizeof(RGB555);
       }

--- a/libraries/pico_graphics/pico_graphics_pen_dv_p5.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_dv_p5.cpp
@@ -93,13 +93,13 @@ namespace pimoroni {
 
         uint8_t current_palette = driver.get_local_palette_index();
 
-        RGB888 *driver_palette = driver.get_palette(current_palette);
-        RGB palette[palette_size];
-        for(auto i = 0u; i < palette_size; i++) {
-            palette[i] = RGB((uint)driver_palette[i]);
-        }
-
         if(!cache_built) {
+            RGB888 *driver_palette = driver.get_palette(current_palette);
+            RGB palette[palette_size];
+            for(auto i = 0u; i < palette_size; i++) {
+                palette[i] = RGB((uint)driver_palette[i]);
+            }
+
             for(uint i = 0; i < 512; i++) {
                 RGB cache_col((i & 0x1C0) >> 1, (i & 0x38) << 2, (i & 0x7) << 5);
                 get_dither_candidates(cache_col, palette, palette_size, candidate_cache[i]);

--- a/libraries/pico_graphics/pico_graphics_pen_dv_rgb555.cpp
+++ b/libraries/pico_graphics/pico_graphics_pen_dv_rgb555.cpp
@@ -1,5 +1,13 @@
 #include "pico_graphics_dv.hpp"
 
+#ifndef MICROPY_BUILD_TYPE
+#define mp_printf(_, ...) printf(__VA_ARGS__);
+#else
+extern "C" {
+#include "py/runtime.h"
+}
+#endif
+
 namespace pimoroni {
     PicoGraphics_PenDV_RGB555::PicoGraphics_PenDV_RGB555(uint16_t width, uint16_t height, DVDisplay &dv_display)
       : PicoGraphics(width, height, nullptr),
@@ -42,4 +50,75 @@ namespace pimoroni {
 
         driver.write_pixel(p, blended);
     };
+
+    bool PicoGraphics_PenDV_RGB555::render_pico_vector_tile(const Rect &src_bounds, uint8_t* alpha_data, uint32_t stride, uint8_t alpha_type) {
+        
+        // Alpha configuration
+        const uint8_t alpha_map4[4] = { 0, 8, 12, 15 };
+        const uint8_t alpha_map16[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+        const uint8_t* alpha_map = (alpha_type == 2) ? alpha_map16 : alpha_map4;
+        const uint8_t alpha_max = (alpha_type == 2) ? 16 : 4;
+
+        const Rect bounds = src_bounds.intersection(clip);
+        if (bounds.w <= 0 || bounds.h <= 0) return true;
+        
+        // Double buffering - in the main loop one buffer is being written to the PSRAM or read into 
+        // in the background while the other is processed
+        uint16_t buf0[128] alignas(4);
+        uint16_t buf1[128] alignas(4);
+        if (bounds.w > 128 || bounds.h > 128) {
+            return false;
+        }
+        uint16_t* rbuf = buf0;
+        uint16_t* wbuf = buf1;
+
+        // Start reading the first row
+        uint32_t address = driver.point_to_address({bounds.x, bounds.y});
+        uint32_t row_len_in_words = (bounds.w + 1) >> 1;
+        driver.raw_read_async(address, (uint32_t*)rbuf, row_len_in_words);
+
+        const uint32_t colour_expanded = (uint32_t(color & 0x7C00) << 10) | (uint32_t(color & 0x3E0) << 5) | (color & 0x1F);
+        uint32_t address_stride = driver.frame_row_stride();
+
+        driver.raw_wait_for_finish_blocking();
+
+        for (int32_t y = 0; y < bounds.h; ++y) {
+            std::swap(wbuf, rbuf);
+
+            uint32_t prev_address = address;
+
+            address += address_stride;
+
+            // Process this row
+            uint8_t* alpha_ptr = &alpha_data[stride * y];
+            for (int32_t x = 0; x < bounds.w; ++x) {
+                uint8_t alpha = *alpha_ptr++;
+                if (alpha >= alpha_max) {
+                    wbuf[x] = color;
+                } else if (alpha > 0) {
+
+                    uint16_t src = wbuf[x];
+                    alpha = alpha_map[alpha];
+
+                    // Who said Cortex-M0 can't do SIMD?
+                    const uint32_t src_expanded = (uint32_t(src & 0x7C00) << 10) | (uint32_t(src & 0x3E0) << 5) | (src & 0x1F);
+                    const uint32_t blended = src_expanded * (16 - alpha) + colour_expanded * alpha;
+                    wbuf[x] = ((blended >> 14) & 0x7C00) | ((blended >> 9) & 0x3E0) | ((blended >> 4) & 0x1F);
+                }
+
+                // Halfway through processing this row switch from writing previous row to reading the next
+                if (x == (int32_t)row_len_in_words && y+1 < bounds.h) {
+                    driver.raw_read_async(address, (uint32_t*)rbuf, row_len_in_words);
+                }
+            }
+
+            // Write the row out while we loop on to the next
+            driver.raw_write_async(prev_address, (uint32_t*)wbuf, row_len_in_words);
+        }
+
+        // Wait for the last write to finish as we are writing from stack
+        driver.raw_wait_for_finish_blocking();
+
+        return true;
+    }
 }


### PR DESCRIPTION
This exposes some raw async RAM access functions from DV Display, and uses them to do streaming memory read/write while the CPU is doing the alpha blend.

The pretty poly optimizations made a bigger difference, but this was still 20-30ms improvement on the vector clock.

Needs the interface change from pimoroni-pico, so don't merge yet.