### PR TITLE
Some CMake improvements

### DIFF
--- a/drivers/dv_display/dv_display.cmake
+++ b/drivers/dv_display/dv_display.cmake
@@ -1,13 +1,24 @@
 set(DRIVER_NAME dv_display)
+
+# SWD loader
+add_library(swd_load INTERFACE)
+
+target_sources(swd_load INTERFACE
+  ${CMAKE_CURRENT_LIST_DIR}/swd_load.cpp)
+
+target_include_directories(swd_load INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+
+pico_generate_pio_header(swd_load ${CMAKE_CURRENT_LIST_DIR}/swd.pio)
+
+target_link_libraries(swd_load INTERFACE pico_stdlib)
+
+# main DV display driver
 add_library(${DRIVER_NAME} INTERFACE)
 
 target_sources(${DRIVER_NAME} INTERFACE
-  ${CMAKE_CURRENT_LIST_DIR}/${DRIVER_NAME}.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/swd_load.cpp)
+  ${CMAKE_CURRENT_LIST_DIR}/${DRIVER_NAME}.cpp)
 
 target_include_directories(${DRIVER_NAME} INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 
-pico_generate_pio_header(${DRIVER_NAME} ${CMAKE_CURRENT_LIST_DIR}/swd.pio)
-
 # Pull in pico libraries that we need
-target_link_libraries(${DRIVER_NAME} INTERFACE pico_stdlib aps6404 pimoroni_i2c)
+target_link_libraries(${DRIVER_NAME} INTERFACE swd_load pico_stdlib aps6404 pimoroni_i2c)

--- a/picovision.cmake
+++ b/picovision.cmake
@@ -1,10 +1,11 @@
+
+include(drivers/aps6404/aps6404)
+include(drivers/dv_display/dv_display)
+
 set(LIB_NAME picovision)
 add_library(${LIB_NAME} INTERFACE)
 
 target_sources(${LIB_NAME} INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}/drivers/dv_display/dv_display.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/drivers/dv_display/swd_load.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/drivers/aps6404/aps6404.cpp
     ${PIMORONI_PICO_PATH}/libraries/pico_graphics/pico_graphics.cpp
     ${CMAKE_CURRENT_LIST_DIR}/libraries/pico_graphics/pico_graphics_pen_dv_rgb888.cpp
     ${CMAKE_CURRENT_LIST_DIR}/libraries/pico_graphics/pico_graphics_pen_dv_rgb555.cpp
@@ -12,16 +13,11 @@ target_sources(${LIB_NAME} INTERFACE
     ${PIMORONI_PICO_PATH}/libraries/pico_graphics/types.cpp
 )
 
-pico_generate_pio_header(${LIB_NAME} ${CMAKE_CURRENT_LIST_DIR}/drivers/dv_display/swd.pio)
-pico_generate_pio_header(${LIB_NAME} ${CMAKE_CURRENT_LIST_DIR}/drivers/aps6404/aps6404.pio)
-
 target_include_directories(${LIB_NAME} INTERFACE
     ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_CURRENT_LIST_DIR}/drivers/aps6404
-    ${CMAKE_CURRENT_LIST_DIR}/drivers/dv_display
     ${CMAKE_CURRENT_LIST_DIR}/libraries/pico_graphics     # for pico_graphics_dv.hpp
     ${PIMORONI_PICO_PATH}/libraries/pico_graphics  # for pico_graphics.hpp
     ${PIMORONI_PICO_PATH}/libraries/pngdec
 )
 
-target_link_libraries(${LIB_NAME} INTERFACE pico_stdlib pimoroni_i2c hardware_i2c hardware_pio hardware_dma)
+target_link_libraries(${LIB_NAME} INTERFACE aps6404 dv_display pico_stdlib)


### PR DESCRIPTION
Mostly so I can use the RAM driver and SWD loader without `dv_display`... or a dependency on pimoroni-pico.