### PR TITLE
Fix odd numbered scroll groups if header is rewritten

### DIFF
--- a/drivers/dv_display/dv_display.cpp
+++ b/drivers/dv_display/dv_display.cpp
@@ -215,6 +215,10 @@ namespace pimoroni {
   }
 
   void DVDisplay::setup_scroll_group(const Point& p, int idx, int wrap_from_x, int wrap_from_y, int wrap_to_x, int wrap_to_y) {
+    if (idx < 1 || idx > 7) {
+      return;
+    }
+
     int16_t wrap_position = 0;
     int16_t wrap_offset = 0;
     if (wrap_from_x > p.x && wrap_from_x < p.x + display_width) {
@@ -263,7 +267,7 @@ namespace pimoroni {
       else {
         ram.read_blocking(addr, buf, maxj);
         for (int j = 0; j < maxj; ++j) {
-          buf[j] &= 0xC0000000;
+          buf[j] &= 0xE0000000;
           buf[j] |= line_type + ((uint32_t)h_repeat << 24) + ((i + j) * frame_width * 3) + base_address;
         }
       }

--- a/drivers/dv_display/dv_display.hpp
+++ b/drivers/dv_display/dv_display.hpp
@@ -223,7 +223,7 @@ namespace pimoroni {
       void write_palette_pixel_span(const Point &p, uint l, uint8_t* data);
       void read_palette_pixel_span(const Point &p, uint l, uint8_t *data);
 
-      // Set the scroll offset and wrap for a set of scanlines on the display.  There are 3 scroll offsets, indexes 1-3.
+      // Set the scroll offset and wrap for a set of scanlines on the display.  There are 7 scroll offsets, indexes 1-7.
       // By default, all scanlines are offset by scroll idx 1, so setting this effectively moves the 
       // top left corner of the display within the frame.
       // When reading across the frame, the display will skip from `from_x` to `to_x`.


### PR DESCRIPTION
Fixes #49.

When we were rewriting the frame table, the low bit of the newly expanded scroll group index was getting clobbered.  Also added checking on the scroll group idx to avoid writing over random I2C registers if you specify an out of bounds scroll group.