### PR TITLE
Reset scroll and sprites when changing pen mode

### DIFF
--- a/drivers/dv_display/dv_display.hpp
+++ b/drivers/dv_display/dv_display.hpp
@@ -286,6 +286,7 @@ namespace pimoroni {
 
     protected:
       uint8_t palette[NUM_PALETTES * PALETTE_SIZE * 3] alignas(4);
+      uint8_t change_mode = 0;
       uint8_t rewrite_header = 0;
       uint8_t rewrite_palette = 0;
       uint8_t current_palette = 0;


### PR DESCRIPTION
I don't think `set_mode()` is exposed to MicroPython - but I reliased it could have similar crash problems when scroll was in use as doing a full stop/start did.  This makes it safer by clearing all the scroll groups and sprites.