### PR TITLE
Bug Fix in Seafax example: Changed BBC feed URLs to https to avoid error following redirects.

### DIFF
--- a/examples/seafax.py
+++ b/examples/seafax.py
@@ -21,9 +21,9 @@ except ImportError:
     print("Create secrets.py with your WiFi credentials")
 
 # Uncomment one URL to use (Top Stories, World News and Technology)
-# URL = "http://feeds.bbci.co.uk/news/rss.xml"
-# URL = "http://feeds.bbci.co.uk/news/world/rss.xml"
-URL = "http://feeds.bbci.co.uk/news/technology/rss.xml"
+# URL = "https://feeds.bbci.co.uk/news/rss.xml"
+# URL = "https://feeds.bbci.co.uk/news/world/rss.xml"
+URL = "https://feeds.bbci.co.uk/news/technology/rss.xml"
 
 display = PicoGraphics(pen_type=PEN_RGB555, width=640, height=480)
 


### PR DESCRIPTION
The BBC feed URLs were all http, but these redirect to https versions of the same URL.  The code wasn't following the redirect and would fail like this:

```
>>> %Run -c $EDITOR_CONTENT

MPY: soft reboot
Start I2C
Started
connecting...
Traceback (most recent call last):
  File "<stdin>", line 196, in <module>
  File "<stdin>", line 165, in update
  File "<stdin>", line 153, in get_rss
  File "urllib/urequest.py", line 62, in urlopen
NotImplementedError: Redirects not yet supported
```

Changing the URLs to https fixes this:

```
>>> %Run -c $EDITOR_CONTENT

MPY: soft reboot
Start I2C
Started
connecting...
```

(expected output appears on the HDMI display).