### PR TITLE
Fix -Wignored-qualifiers warnings

### DIFF
--- a/drivers/aps6404/aps6404.cpp
+++ b/drivers/aps6404/aps6404.cpp
@@ -68,7 +68,7 @@ namespace {
 static const pio_program* pio_prog[2] = {nullptr, nullptr};
 static uint16_t pio_offset[2] = {0xffff, 0xffff};
 
-const void pio_remove_exclusive_program(PIO pio) {
+void pio_remove_exclusive_program(PIO pio) {
     uint8_t pio_index = pio == pio0 ? 0 : 1;
     const pio_program* current_program = pio_prog[pio_index];
     uint16_t current_offset = pio_offset[pio_index];
@@ -79,7 +79,7 @@ const void pio_remove_exclusive_program(PIO pio) {
     }
 }
 
-const uint16_t pio_change_exclusive_program(PIO pio, const pio_program* prog) {
+uint16_t pio_change_exclusive_program(PIO pio, const pio_program* prog) {
     pio_remove_exclusive_program(pio);
     uint8_t pio_index = pio == pio0 ? 0 : 1;
     pio_prog[pio_index] = prog;

--- a/drivers/dv_display/swd_load.cpp
+++ b/drivers/dv_display/swd_load.cpp
@@ -23,8 +23,8 @@ static float pio_clkdiv;
 
 PIO swd_pio = pio0;
 
-extern const uint16_t pio_change_exclusive_program(PIO pio, const pio_program* prog);
-extern const void pio_remove_exclusive_program(PIO pio);
+uint16_t pio_change_exclusive_program(PIO pio, const pio_program* prog);
+void pio_remove_exclusive_program(PIO pio);
 
 static void wait_for_idle() {
     uint pull_offset = (pio_prog == &swd_raw_write_program) ? 2 : 


### PR DESCRIPTION
Fixes a few of these:

```
type qualifiers ignored on function return type [-Wignored-qualifiers]
```

When building with `-Wextra`.


... and I'm going to pretend I didn't see that swd_load is declaring a function defined in another driver...