### PR TITLE
Compilation error in PicoGraphics

### DIFF
--- a/libraries/pico_graphics/pico_graphics_dv.hpp
+++ b/libraries/pico_graphics/pico_graphics_dv.hpp
@@ -19,6 +19,8 @@ namespace pimoroni {
       virtual void set_depth(uint8_t new_depth) {}
       virtual void set_bg(uint c) {};
 
+      virtual bool render_pico_vector_tile(const Rect &bounds, uint8_t* alpha_data, uint32_t stride, uint8_t alpha_type);
+
       PicoGraphicsDV(uint16_t width, uint16_t height, DVDisplay &dv_display)
       : PicoGraphics(width, height, nullptr),
         driver(dv_display)


### PR DESCRIPTION
When compiling the Picovision C++ boilerplate project (unchanged) I got compilation errors saying that the PicoGraphics library has some function definitions that weren't being overloaded. Happy to attach my build log from that.

Added a virtual function signature to the base class (PicoGraphicsDV) for overridden methods since the compiler threw an error saying neither method was actually overloading anything and no matching definition was found in PicoGraphics class.